### PR TITLE
feat: expand `DeepLTextTranslator` parameters

### DIFF
--- a/deepl_haystack/components.py
+++ b/deepl_haystack/components.py
@@ -1,10 +1,18 @@
 """DeepL translator components."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
-from deepl import Formality, TextResult, Translator
-from haystack import Document, component, default_from_dict, default_to_dict
+from deepl import (
+    Formality,
+    SplitSentences,
+    TextResult,
+    Translator,
+    http_client,
+)
+from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.utils import Secret, deserialize_secrets_inplace
+
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -17,6 +25,17 @@ class DeepLTextTranslator:
         source_lang: Optional[str] = None,
         target_lang: str = "EN-US",
         formality: Union[str, Formality, None] = None,
+        *,
+        max_retries: int = 5,
+        preserve_formatting: bool = False,
+        split_sentences: Union[str, SplitSentences, None] = None,
+        context: Optional[str] = None,
+        glossary: Union[str, None] = None,
+        tag_handling: Literal[None, "xml", "html"] = None,
+        outline_detection: bool = True,
+        non_splitting_tags: Union[str, List[str], None] = None,
+        splitting_tags: Union[str, List[str], None] = None,
+        ignore_tags: Union[str, List[str], None] = None,
     ):
         """Create a DeepLTextTranslator component.
 
@@ -26,16 +45,73 @@ class DeepLTextTranslator:
                 for German, or "ES" for Spanish.
             target_lang: Language code to translate the text into,
                 defaults to "EN", for English.
-            formality: Desired formality for translation, as
-            Formality enum, "less", "more", "prefer_less",
-            "prefer_more", or "default".
+            formality: Controls whether translations should lean toward
+                informal or formal language. Can be expressed as a string
+                or as a Formality enum. Possible values are "less", "more",
+                "prefer_less", "prefer_more", or "default".
+                This feature currently only works for the following languages:
+                DE (German), FR (French), IT (Italian), ES (Spanish),
+                NL (Dutch), PL (Polish), PT-BR and PT-PT (Portuguese),
+                JA (Japanese), and RU (Russian).
+            max_retries: Maximum number of network retries after a failed HTTP
+                request. Default retries is set to 5.
+            preserve_formatting: Controls automatic formatting correction.
+                Set to `True` to prevent automatic correction of formatting.
+            split_sentences: Controls how the translation engine should split
+                input into sentences before translation. Can be expressed as
+                a string or as a SplitSentences enum. Possible values are:
+                - 0: 0 means OFF. No splitting at all, whole input is treated
+                as one sentence. Use this option if the input text is already
+                split into sentences, to prevent the engine from splitting the sentence
+                unintentionally.
+                - 1: 1 means ALL. (default) splits on punctuation and on newlines.
+                - 'nonewlines': splits on punctuation only, ignoring newlines.
+            context: Use this setting to include additional context that can
+                influence a translation without being translated itself.
+                Providing additional context can potentially improve translation
+                quality, especially for short, low-context source texts such as
+                product names on an e-commerce website, article headlines on a
+                news website, or UI elements.
+                For more information and examples, refer to the
+                [DeepL API documentation](https://developers.deepl.com/docs/api-reference/translate).
+            glossary: glossary ID to use for translation. Must match specified
+                `source_lang` and `target_lang`.
+            tag_handling: Optional type of tags to parse before translation.
+                Only "xml" and "html" are currently available.
+            outline_detection: Set to False to disable automatic tag detection.
+            non_splitting_tags: XML tags that should not be used to split text
+                into sentences.
+            splitting_tags: XML tags that should be used to split text into
+                sentences.
+            ignore_tags: XML tags containing text that should not be translated.
 
         """
+        if not isinstance(target_lang, str) or not target_lang:
+            raise ValueError(
+                "`target_lang` must be a string representing a language code. "
+                "For more information about DeepL supported languages, "
+                "see https://developers.deepl.com/docs/resources/supported-languages"
+            )
+
         self.api_key: Secret = api_key
+        self.max_retries: int = max_retries
+        http_client.max_network_retries = self.max_retries
         self.client: Translator = Translator(auth_key=self.api_key.resolve_value())
+
         self.source_lang: Optional[str] = source_lang
         self.target_lang: str = target_lang
         self.formality: Formality = Formality(formality or Formality.DEFAULT)
+        self.preserve_formatting: bool = preserve_formatting
+        self.split_sentences: SplitSentences = SplitSentences(
+            split_sentences or SplitSentences.DEFAULT
+        )
+        self.context: Optional[str] = context
+        self.glossary: Union[str, None] = glossary
+        self.tag_handling: Literal[None, "xml", "html"] = tag_handling
+        self.outline_detection: bool = outline_detection
+        self.non_splitting_tags: Union[str, List[str], None] = non_splitting_tags
+        self.splitting_tags: Union[str, List[str], None] = splitting_tags
+        self.ignore_tags: Union[str, List[str], None] = ignore_tags
 
     @component.output_types(translation=str, meta=Dict[str, Any])
     def run(self, text: str, source_lang: Optional[str] = None):
@@ -60,17 +136,30 @@ class DeepLTextTranslator:
                 "please use the DeepLDocumentTranslator."
             )
 
+        if not text:
+            raise ValueError("Empty text provided.")
+
         translation = self.client.translate_text(
             text,
             source_lang=source_lang or self.source_lang or None,
             target_lang=self.target_lang,
             formality=self.formality,
+            preserve_formatting=self.preserve_formatting,
+            split_sentences=self.split_sentences,
+            context=self.context,
+            glossary=self.glossary,
+            tag_handling=self.tag_handling,
+            outline_detection=self.outline_detection,
+            non_splitting_tags=self.non_splitting_tags,
+            splitting_tags=self.splitting_tags,
+            ignore_tags=self.ignore_tags,
         )
         assert isinstance(translation, TextResult)
         meta = {
             "source_lang": translation.detected_source_lang,
             "language": self.target_lang,
         }
+
         return {"translation": translation.text, "meta": meta}
 
     def to_dict(self) -> Dict[str, Any]:
@@ -85,6 +174,15 @@ class DeepLTextTranslator:
             source_lang=self.source_lang,
             target_lang=self.target_lang,
             formality=self.formality.value,
+            preserve_formatting=self.preserve_formatting,
+            split_sentences=self.split_sentences.value,
+            context=self.context,
+            glossary=self.glossary,
+            tag_handling=self.tag_handling,
+            outline_detection=self.outline_detection,
+            non_splitting_tags=self.non_splitting_tags,
+            splitting_tags=self.splitting_tags,
+            ignore_tags=self.ignore_tags,
         )
 
     @classmethod

--- a/tests/test_deepl_document_translator.py
+++ b/tests/test_deepl_document_translator.py
@@ -249,7 +249,7 @@ class TestDeepLDocumentTranslator:
     def test_live_run_wrong_source_language(self):
         component = DeepLDocumentTranslator(source_lang="something-wrong")
         with pytest.raises(
-            DeepLException, match=r".* Value for 'source_lang' not supported."
+            DeepLException, match=r".* Value for source_lang not supported"
         ):
             component.run([Document(content="Whatever")])
 
@@ -261,6 +261,6 @@ class TestDeepLDocumentTranslator:
     def test_live_run_wrong_target_language(self):
         component = DeepLDocumentTranslator(target_lang="something-wrong")
         with pytest.raises(
-            DeepLException, match=r".* Value for 'target_lang' not supported."
+            DeepLException, match=r".* Value for target_lang not supported"
         ):
             component.run([Document(content="Whatever")])

--- a/tests/test_deepl_text_translator.py
+++ b/tests/test_deepl_text_translator.py
@@ -259,17 +259,20 @@ class TestDeepLTextTranslator:
 
         mock_translation.assert_not_called()
 
-    @patch.object(
-        Translator, "translate_text", side_effect=DeepLException("Error translating")
-    )
-    def test_run_error_translating(self, monkeypatch, mock_translation):
+    def test_run_error_translating(self, monkeypatch):
         monkeypatch.setenv("DEEPL_API_KEY", "fake-api-key")
-        component = DeepLTextTranslator(
-            source_lang=DEFAULT_SOURCE_LANG,
-            target_lang="ES",
-        )
-        with pytest.raises(DeepLException, match="Error translating"):
-            component.run("Error translating")
+
+        with patch.object(
+            Translator,
+            "translate_text",
+            side_effect=DeepLException("Error translating"),
+        ):
+            component = DeepLTextTranslator(
+                source_lang=DEFAULT_SOURCE_LANG,
+                target_lang="ES",
+            )
+            with pytest.raises(DeepLException, match="Error translating"):
+                component.run("Error translating")
 
     def test_run_with_source_lang(self, monkeypatch, mock_translation):
         """Test the run method of the DeepLTextTranslator class."""


### PR DESCRIPTION
As anticipated in #114, this is the first of two PRs to migrate our internal implementations to this Haystack integration.

In short, I am exposing in `DeepLTextTranslator` some API parameters available in DeepL for configuring the translation.

(I'll do another PR with updates to the Document Translator component)