### PR TITLE
feat: support Haystack 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "deepl>=1.19.1,<2",
-    "haystack-ai>=2.0.0,<3",
+    "haystack-ai>=2.0.0,<4",
 ]
 
 [project.urls]

--- a/tests/test_deepl_document_translator.py
+++ b/tests/test_deepl_document_translator.py
@@ -1,11 +1,12 @@
 """Test cases for DeepL translator components."""
 
+import inspect
 import os
 from typing import Any
 
 import pytest
 from deepl import DeepLException, Formality, SplitSentences, Translator
-from haystack import Document
+from haystack import Document, Pipeline
 from haystack.utils import Secret
 
 from deepl_haystack import DeepLDocumentTranslator
@@ -217,6 +218,31 @@ class TestDeepLDocumentTranslator:
             ValueError, match=r"None of the .* environment variables are set"
         ):
             DeepLDocumentTranslator.from_dict(data)
+
+    def test_pipeline_serialization_roundtrip(self, monkeypatch):
+        """The component survives a pipeline serialization round-trip.
+
+        Haystack 3.x gates pipeline deserialization through a trusted-module
+        allowlist that only covers Haystack's own namespaces, so loading a
+        pipeline that contains a component from this package requires listing
+        it in ``allowed_modules``. Haystack 2.x has no such parameter, so it is
+        only passed when supported.
+        """
+        monkeypatch.setenv("DEEPL_API_KEY", "test-api-key")
+        pipeline = Pipeline()
+        pipeline.add_component(
+            "translator", DeepLDocumentTranslator(target_lang=["ES", "FR"])
+        )
+
+        dumped = pipeline.dumps()
+        if "allowed_modules" in inspect.signature(Pipeline.loads).parameters:
+            loaded = Pipeline.loads(dumped, allowed_modules=["deepl_haystack"])
+        else:
+            loaded = Pipeline.loads(dumped)
+
+        component = loaded.get_component("translator")
+        assert isinstance(component, DeepLDocumentTranslator)
+        assert component.target_lang == ["ES", "FR"]
 
     def test_run_one_doc(self, monkeypatch, mock_translation, caplog):
         """Test the run method of the DeepLDocumentTranslator class.

--- a/tests/test_deepl_text_translator.py
+++ b/tests/test_deepl_text_translator.py
@@ -1,11 +1,13 @@
 """Test cases for DeepL translator components."""
 
+import inspect
 import os
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from deepl import DeepLException, Formality, SplitSentences, Translator
+from haystack import Pipeline
 from haystack.utils import Secret
 
 from deepl_haystack import DeepLTextTranslator
@@ -210,6 +212,29 @@ class TestDeepLTextTranslator:
             ValueError, match=r"None of the .* environment variables are set"
         ):
             DeepLTextTranslator.from_dict(data)
+
+    def test_pipeline_serialization_roundtrip(self, monkeypatch):
+        """The component survives a pipeline serialization round-trip.
+
+        Haystack 3.x gates pipeline deserialization through a trusted-module
+        allowlist that only covers Haystack's own namespaces, so loading a
+        pipeline that contains a component from this package requires listing
+        it in ``allowed_modules``. Haystack 2.x has no such parameter, so it is
+        only passed when supported.
+        """
+        monkeypatch.setenv("DEEPL_API_KEY", "test-api-key")
+        pipeline = Pipeline()
+        pipeline.add_component("translator", DeepLTextTranslator(target_lang="ES"))
+
+        dumped = pipeline.dumps()
+        if "allowed_modules" in inspect.signature(Pipeline.loads).parameters:
+            loaded = Pipeline.loads(dumped, allowed_modules=["deepl_haystack"])
+        else:
+            loaded = Pipeline.loads(dumped)
+
+        component = loaded.get_component("translator")
+        assert isinstance(component, DeepLTextTranslator)
+        assert component.target_lang == "ES"
 
     def test_run(self, monkeypatch, mock_translation):
         """Test the run method of the DeepLTextTranslator class."""


### PR DESCRIPTION
## What & why

Haystack v3 is about to be released (I am one of the maintainers). deepl-haystack currently pins
`haystack-ai>=2.0.0,<3`. This PR removes that limitation so the integration works with **both 2.x and 3.x**.

## Changes

- **`pyproject.toml`**: widen the cap from `haystack-ai>=2.0.0,<3` to `haystack-ai>=2.0.0,<4`.
- **tests**: add pipeline serialization round-trip tests for both `DeepLTextTranslator`
  and `DeepLDocumentTranslator`. 

The component source code is unchanged and is already compatible with both major versions.

## One thing to know about Haystack 3.x

Haystack 3.x gates pipeline deserialization through a *trusted-module allowlist*
that only covers Haystack's own namespaces (`haystack`, `haystack_integrations`,
`haystack_experimental`). Because this package lives in the `deepl_haystack`
namespace, loading a serialized pipeline that contains one of its components
requires the caller to allow the module explicitly:

```python
pipeline = Pipeline.loads(dumped, allowed_modules=["deepl_haystack"])
```

## Testing

Verified locally against both versions (unit tests, `mypy`, and `ruff`):

| Check | Haystack 2.30.2 | Haystack 3.0.0rc0 |
|-------|:---------------:|:-----------------:|
| `pytest -m "not integration"` | ✅ | ✅ |
| `mypy deepl_haystack` | ✅ | ✅ |
| `ruff check` / `ruff format --check` | ✅ | ✅ |

Integration tests (`-m integration`) require a live `DEEPL_API_KEY` and were not run.

🤖 Partly generated with [Claude Code](https://claude.com/claude-code)